### PR TITLE
install manpage tv.1

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -10,3 +10,6 @@ cargo-bundle-licenses \
     --output THIRDPARTY.yml
 
 cargo install --no-track --locked --root "$PREFIX" --path .
+
+mkdir -p "$PREFIX/share/man/man1/"
+install -m 644 man/tv.1 "$PREFIX/share/man/man1/tv.1"

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -11,7 +11,7 @@ source:
   sha256: fc7547d45d112599559434ad438bb05c7dab0484fae15d9fa5625069dc5b9687
 
 build:
-  number: 0
+  number: 1
 
 
 requirements:


### PR DESCRIPTION
Install manpage added in upstream release 0.10.10

Upstream: https://github.com/alexpasmantier/television/commit/0edf224502cc843500ae48e5290a264247930efa

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
